### PR TITLE
Add modules to split preprocessing from prediction

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -1,0 +1,117 @@
+import os
+import json
+import logging
+
+import torch
+import numpy as np
+from transformers import AutoConfig, AutoTokenizer
+from tqdm import tqdm
+
+from dataset import DocREDProcessor, DocREDExample, DocREDInputFeatures
+from model import BertForDocRED, RobertaForDocRED
+from run_docred import set_seed, setup_SSAN_parser, predict_from_examples_and_features
+
+
+def deserialize_examples_file(path_to_examples):
+    """Deserialize a file of serialized DocREDExample objects."""
+    with open(path_to_examples, "r") as f:
+        example_strings = json.load(f)
+
+    return (DocREDExample(**json.loads(s)) for s in example_strings)
+
+def deserialize_features_file(path_to_features):
+    """Deserialize a file of serialized DocREDInputFeatures objects."""
+    ndarray_fields = ["ent_mask", "ent_distance", "structure_mask", "label", "label_mask"]
+    decode_numpy_fields = lambda feature_dict: {k, v}
+
+    with open(path_to_features, "r") as f:
+        features_strings = json.load(f)
+
+    for s in features_strings:
+        features_dict = json.loads(s)
+        for field in ndarray_fields:
+            features_dict[field] = np.asarray(features_dict[field])
+
+        yield DocREDInputFeatures(**features_dict)
+
+
+def main():
+    logging.basicConfig(
+        format='%(asctime)s %(levelname)-8s %(message)s',
+        level=logging.INFO,
+        datefmt='%Y-%m-%d %H:%M:%S')
+
+    parser = setup_SSAN_parser()
+    parser.add_argument("--examples_file", required=True, help="File containing serialized DocREDExample objects.")
+    parser.add_argument("--features_file", required=True, help="File containing serialized DocREDInputFeatures objects.")
+    args = parser.parse_args()
+
+    # Setup CUDA, GPU & distributed training
+    if args.local_rank == -1 or args.no_cuda:
+        device = torch.device("cuda" if torch.cuda.is_available() and not args.no_cuda else "cpu")
+        args.n_gpu = 0 if args.no_cuda else torch.cuda.device_count()
+    else:  # Initializes the distributed backend which will take care of sychronizing nodes/GPUs
+        torch.cuda.set_device(args.local_rank)
+        device = torch.device("cuda", args.local_rank)
+        torch.distributed.init_process_group(backend="nccl")
+        args.n_gpu = 1
+    args.device = device
+
+    args.predict_thresh = 0.46544307
+
+    logging.info(f"n_gpu: {args.n_gpu} and device: {args.device}")
+
+
+    logging.info("Deserializing examples from file")
+    examples_gen = deserialize_examples_file(args.examples_file)
+    examples = list(examples_gen)
+
+    logging.info("Deserializing features from file")
+    features_gen = deserialize_features_file(args.features_file)
+    features = list(features_gen)
+
+    logging.info("Finished deserialization")
+
+
+    ModelArch = None
+    if args.model_type == 'roberta':
+        ModelArch = RobertaForDocRED
+    elif args.model_type == 'bert':
+        ModelArch = BertForDocRED
+
+    if args.no_naive_feature:
+        with_naive_feature = False
+    else:
+        with_naive_feature = True
+
+
+    # Set seed
+    set_seed(args)
+
+    processor = DocREDProcessor()
+    label_map = processor.get_label_map(args.data_dir)
+    num_labels = len(label_map.keys())
+
+
+    config = AutoConfig.from_pretrained(
+        args.config_name if args.config_name else args.model_name_or_path,
+        cache_dir=args.cache_dir if args.cache_dir else None,
+    )
+
+
+    # predict
+    tokenizer = AutoTokenizer.from_pretrained(args.checkpoint_dir, do_lower_case=args.do_lower_case)
+    model = ModelArch.from_pretrained(args.checkpoint_dir,
+                                      from_tf=bool(".ckpt" in args.model_name_or_path),
+                                      config=config,
+                                      cache_dir=args.cache_dir if args.cache_dir else None,
+                                      num_labels=num_labels,
+                                      max_ent_cnt=args.max_ent_cnt,
+                                      with_naive_feature=with_naive_feature,
+                                      entity_structure=args.entity_structure)
+    model.to(args.device)
+
+    predict_from_examples_and_features(args, model, tokenizer, examples, features)
+
+if __name__ == "__main__":
+    main()

--- a/preprocess.py
+++ b/preprocess.py
@@ -1,0 +1,83 @@
+import os
+import json
+import logging
+
+import torch
+import numpy as np
+from transformers import AutoConfig, AutoTokenizer
+from tqdm import tqdm
+
+from dataset import DocREDProcessor
+from dataset import docred_convert_examples_to_features as convert_examples_to_features
+from run_docred import setup_SSAN_parser
+
+
+def file_to_examples_and_features(args):
+    """Convert an SSAN input file into DocREDExample and DocREDInputFeatures objects."""
+    processor = DocREDProcessor()
+    label_map = processor.get_label_map(args.data_dir)
+    num_labels = len(label_map.keys())
+
+
+    logging.info("Loading examples from file")
+    examples = processor.get_examples_from_file(args.input_file)
+
+
+    tokenizer = AutoTokenizer.from_pretrained(
+            args.model_name_or_path,
+            do_lower_case=args.do_lower_case,
+            cache_dir=None
+    )
+
+    logging.info("Converting examples to features")
+    features = convert_examples_to_features(
+        examples,
+        args.model_type,
+        tokenizer,
+        max_length=args.max_seq_length,
+        max_ent_cnt=args.max_ent_cnt,
+        label_map=label_map
+    )
+
+    logging.info("Finished converting examples to features")
+
+    return examples, features
+
+
+def main():
+    logging.basicConfig(
+        format='%(asctime)s %(levelname)-8s %(message)s',
+        level=logging.INFO,
+        datefmt='%Y-%m-%d %H:%M:%S')
+
+    parser = setup_SSAN_parser()
+    parser.add_argument("--input_file", required=True, help="Input file for preprocessing.")
+    args = parser.parse_args()
+
+
+    examples, features = file_to_examples_and_features(args)
+
+
+    input_dir, input_fname = os.path.split(args.input_file)
+    input_dir = os.path.abspath(input_dir)
+
+    # Write example and feature files next to input file
+    write_examples_to = os.path.join(input_dir, f"{os.path.splitext(input_fname)[0]}_examples.json")
+    write_features_to = os.path.join(input_dir, f"{os.path.splitext(input_fname)[0]}_features.json")
+
+
+    logging.info("Json serializing examples and features...")
+    json_examples = [e.to_json_string() for e in examples]
+    json_features = [f.to_json_string() for f in features]
+
+    logging.info(f"Writing examples to {write_examples_to}")
+    with open(write_examples_to, "w") as f:
+        json.dump(json_examples, f)
+
+    logging.info(f"Writing features to {write_features_to}")
+    with open(write_features_to, "w") as f:
+        json.dump(json_features, f)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This commit adds modules for performing the preprocessing steps independently from the prediction steps. This will allow us to perform the preprocessing on cheap CPU/databricks clusters and minimize the running time of the GPU machine doing the inference. 